### PR TITLE
[FIX] View Topic Subcommand Errors When There Where No Topics In The Database

### DIFF
--- a/apps/bot/src/plugins/configuration/subcommands/viewTopicsSubCommand.ts
+++ b/apps/bot/src/plugins/configuration/subcommands/viewTopicsSubCommand.ts
@@ -26,33 +26,39 @@ export const ViewTopicsSubCommand = defineSubCommand({
             return;
         }
 
-        const components = [
-            {
-                components: [
-                    {
-                        customId: `add_topic_subcommand_button_previous_${interaction.user.id}`,
-                        disabled: state.addTopicPages.page === 0,
-                        label: 'Previous',
-                        style: ButtonStyle.Primary as const,
-                        type: ComponentType.Button as const,
-                    },
-                    {
-                        customId: `add_topic_subcommand_button_home_${interaction.user.id}`,
-                        label: 'Home',
-                        style: ButtonStyle.Secondary as const,
-                        type: ComponentType.Button as const,
-                    },
-                    {
-                        customId: `add_topic_subcommand_button_next_${interaction.user.id}`,
-                        disabled: state.addTopicPages.page === state.addTopicPages.pages.length - 1,
-                        label: 'Next',
-                        style: ButtonStyle.Primary as const,
-                        type: ComponentType.Button as const,
-                    },
-                ],
-                type: ComponentType.ActionRow as const,
-            },
-        ];
+        var components;
+        if (topicsExistInDB.length === 0) {
+            components = [];
+        } else {
+            components = [
+                {
+                    components: [
+                        {
+                            customId: `add_topic_subcommand_button_previous_${interaction.user.id}`,
+                            disabled: state.addTopicPages.page === 0,
+                            label: 'Previous',
+                            style: ButtonStyle.Primary as const,
+                            type: ComponentType.Button as const,
+                        },
+                        {
+                            customId: `add_topic_subcommand_button_home_${interaction.user.id}`,
+                            label: 'Home',
+                            style: ButtonStyle.Secondary as const,
+                            type: ComponentType.Button as const,
+                        },
+                        {
+                            customId: `add_topic_subcommand_button_next_${interaction.user.id}`,
+                            disabled:
+                                state.addTopicPages.page === state.addTopicPages.pages.length - 1,
+                            label: 'Next',
+                            style: ButtonStyle.Primary as const,
+                            type: ComponentType.Button as const,
+                        },
+                    ],
+                    type: ComponentType.ActionRow as const,
+                },
+            ];
+        }
 
         await interaction.reply({
             components,
@@ -65,7 +71,7 @@ export const ViewTopicsSubCommand = defineSubCommand({
                                 (string, i) =>
                                     `**${state.addTopicPages.page * 10 + i + 1}.** *${string}*`,
                             )
-                            .join('\n') || 'No topics',
+                            .join('\n') || 'There are no topics configured.',
                     footer: {
                         text: `Page: ${state.addTopicPages.page + 1}/${state.addTopicPages.pages.length} • Total Topics: ${topicsExistInDB.length}`,
                     },

--- a/apps/bot/src/plugins/configuration/subcommands/viewTopicsSubCommand.ts
+++ b/apps/bot/src/plugins/configuration/subcommands/viewTopicsSubCommand.ts
@@ -60,7 +60,7 @@ export const ViewTopicsSubCommand = defineSubCommand({
                 {
                     color: global.embedColor,
                     description:
-                        state.addTopicPages.pages[state.addTopicPages.page]
+                        (state.addTopicPages.pages[state.addTopicPages.page] || [])
                             .map(
                                 (string, i) =>
                                     `**${state.addTopicPages.page * 10 + i + 1}.** *${string}*`,


### PR DESCRIPTION
1. In `viewTopicsSubCommand.ts`, when there was no topics in the database, these was returning `undefined` instead a `map`. Since the handling of the code was prepared to receive a mapping, these was causing `Unhandled promise rejection: TypeError: Cannot read properties of undefined (reading 'map')`


2. The interaction listener also assumed topics would always be present. To prevent the listener to be triggered when there are no topics, I added a verification step in `viewTopicsSubCommand.ts` that only adds components if the retrieved topic list is non-empty, so when there is no topics, there will be no buttons to trigger the listener.