### PR TITLE
[FIX] When a topic get deleted, it was still show in the removed topic embed.

### DIFF
--- a/apps/bot/src/plugins/configuration/subcommands/removeTopicSubCommand.ts
+++ b/apps/bot/src/plugins/configuration/subcommands/removeTopicSubCommand.ts
@@ -90,6 +90,10 @@ export const RemoveTopicSubCommand = defineSubCommand({
 
         const updatedTopics = await ctx.services.settings.getTopics<string>(guildId, 'Topics');
 
+        const updatedPages = chunk(updatedTopics, 10);
+        state.addTopicPages.pages = updatedPages;
+        state.addTopicPages.page = Math.min(state.addTopicPages.page, updatedPages.length - 1);
+
         await interaction.reply({
             components,
             content: `I've removed **${topic}** from the topics list.`,


### PR DESCRIPTION
After a topic is deleted, the list of topics wasn't refreshed, so the deleted topic still appears in the “remove_topic” embe after deletion.