### PR TITLE
[FIX] Fix add_role subcommand and settings view embed

### DIFF
--- a/apps/bot/src/plugins/configuration/subcommands/addRoleSubCommand.ts
+++ b/apps/bot/src/plugins/configuration/subcommands/addRoleSubCommand.ts
@@ -34,10 +34,8 @@ export const AddRoleSubCommand = defineSubCommand({
         const roleExistsInDB = await ctx.services.settings.getRoles<Snowflake>(guildId, config);
 
         if (roleExistsInDB.includes(role.id)) {
-            const roleNames = await Promise.all(
-                roleExistsInDB.map(async (k) => `${(await interaction.guild.roles.fetch(k)).name}`),
-            );
-            const description = roleNames.join(', ') || 'No roles';
+            const roleMentions = roleExistsInDB.map((roleId) => `<@&${roleId}>`);
+            const description = roleMentions.join(', ') || 'No roles';
             await interaction.reply({
                 components: [
                     createConfigurationExistsEmbed({
@@ -56,10 +54,8 @@ export const AddRoleSubCommand = defineSubCommand({
         });
 
         const updatedRoles = await ctx.services.settings.getRoles<Snowflake>(guildId, config);
-        const updatedRoleNames = await Promise.all(
-            updatedRoles.map(async (k) => `${(await interaction.guild.roles.fetch(k)).name}`),
-        );
-        const description = updatedRoleNames.join(', ') || 'No roles';
+        const updatedRoleMentions = updatedRoles.map((roleId) => `<@&${roleId}>`);
+        const description = updatedRoleMentions.join(', ') || 'No roles';
 
         await interaction.reply({
             components: [

--- a/apps/bot/src/plugins/configuration/subcommands/removeRoleSubCommand.ts
+++ b/apps/bot/src/plugins/configuration/subcommands/removeRoleSubCommand.ts
@@ -40,10 +40,8 @@ export const RemoveRoleSubCommand = defineSubCommand({
             });
 
             const updatedRoles = await ctx.services.settings.getRoles<Snowflake>(guildId, config);
-            const updatedRoleNames = await Promise.all(
-                updatedRoles.map(async (k) => `${(await interaction.guild.roles.fetch(k)).name}`),
-            );
-            const description = updatedRoleNames.join(', ') || 'No roles';
+            const updatedRoleMentions = updatedRoles.map((roleId) => `<@&${roleId}>`);
+            const description = updatedRoleMentions.join(', ') || 'No roles';
             await interaction.reply({
                 components: [
                     createConfigurationUpdateEmbed({
@@ -56,10 +54,8 @@ export const RemoveRoleSubCommand = defineSubCommand({
             return;
         }
 
-        const roleNames = await Promise.all(
-            roleExistsInDB.map(async (k) => `${(await interaction.guild.roles.fetch(k)).name}`),
-        );
-        const description = roleNames.join(', ') || 'No roles';
+        const roleMentions = roleExistsInDB.map((roleId) => `<@&${roleId}>`);
+        const description = roleMentions.join(', ') || 'No roles';
 
         await interaction.reply({
             components: [

--- a/apps/bot/src/plugins/configuration/subcommands/viewSubCommand.ts
+++ b/apps/bot/src/plugins/configuration/subcommands/viewSubCommand.ts
@@ -17,7 +17,7 @@ const createField = (
     options: { isChannel: boolean; isRole: boolean; isUser: boolean },
 ) => {
     if (!data || data.length === 0) {
-        return `   * **${field}:** None\n`;
+        return `- **${field}:** None\n`;
     }
 
     const formattedData = data
@@ -32,7 +32,7 @@ const createField = (
                     : id,
         );
     const suffix = data.length > 8 ? ` *(+${data.length - 8} more)*` : '';
-    return `   * **${field}:** ${formattedData.join(', ')}${suffix}\n`;
+    return `- **${field}:** ${formattedData.join(', ')}${suffix}\n`;
 };
 
 export const ViewChannelSubCommand = defineSubCommand({
@@ -115,9 +115,9 @@ export const ViewChannelSubCommand = defineSubCommand({
                         createTable(
                             'Skullboard',
                             [
-                                `   * **Skullboard Channel:** ${Skullboard.SkullboardChannel ? `<#${Skullboard.SkullboardChannel}>` : 'None'}\n`,
-                                `   * **Emoji:** ${Skullboard.SkullboardEmoji ?? '💀'}\n`,
-                                `   * **Reaction Threshold:** ${Skullboard.SkullboardReactionThreshold}\n`,
+                                `- **Skullboard Channel:** ${Skullboard.SkullboardChannel ? `<#${Skullboard.SkullboardChannel}>` : 'None'}\n`,
+                                `- **Emoji:** ${Skullboard.SkullboardEmoji ?? '💀'}\n`,
+                                `- **Reaction Threshold:** ${Skullboard.SkullboardReactionThreshold}\n`,
                             ],
                             false,
                         ) +
@@ -133,9 +133,9 @@ export const ViewChannelSubCommand = defineSubCommand({
                                         isUser: false,
                                     },
                                 ),
-                                `   * **Cooldown:** ${global.slowmodeCooldown}s\n`,
-                                `   * **Message Time Window:** ${global.messageTimeWindow}s\n`,
-                                `   * **Message Threshold:** ${global.messageThreshold}\n`,
+                                `- **Cooldown:** ${global.slowmodeCooldown}s\n`,
+                                `- **Message Time Window:** ${global.messageTimeWindow}s\n`,
+                                `- **Message Threshold:** ${global.messageThreshold}\n`,
                             ],
                             true,
                         ),


### PR DESCRIPTION
1. Update `/settings add_role` subcommand to properly mentions the role (before, was only displaying the name of the role).
1.1 Before: 
![image](https://github.com/user-attachments/assets/206d9f64-ba98-4800-8e55-00543d196345)
1.2 After:
![image](https://github.com/user-attachments/assets/8b95c7f4-7536-4abc-b179-3baaeb5023b4)

--- 

2. Update for `/settings view` to display properly display the list of configuration without giving additional indent starting from the secound line of each configuration:
2.1 Before:
![image](https://github.com/user-attachments/assets/24730887-3064-4518-ac85-1dc1351895f7)
2.2 After:
![image](https://github.com/user-attachments/assets/6d6b43e2-8047-4d35-bedb-d599eaf30678)

---
